### PR TITLE
refactor: organize self-hosted apps under homelab

### DIFF
--- a/src/Components/Terminal.razor.Commands.cs
+++ b/src/Components/Terminal.razor.Commands.cs
@@ -1,3 +1,5 @@
+using MitchfenSite.Models;
+
 namespace MitchfenSite.Components;
 
 public partial class Terminal
@@ -8,7 +10,7 @@ public partial class Terminal
         {
             case "help":
                 OutputLines.Add("  <span class='cyan'>about</span> - get info about me");
-                OutputLines.Add("  <span class='cyan'>projects</span> - coding projects I've done");
+                OutputLines.Add("  <span class='cyan'>projects</span> - hobby projects I've done");
                 OutputLines.Add("  <span class='cyan'>socials</span> - find me elsewhere online");
                 break;
             
@@ -24,29 +26,7 @@ public partial class Terminal
                 break;
 
             case "projects":
-                foreach (var project in Projects)
-                {
-                    var tags = "";
-                    if (project.IsSelfHosted)
-                        tags += "<span class='green'>[self hosted]</span> ";
-                    if (project.IsCli)
-                        tags += "<span class='prompt-char'>[cli]</span> ";
-                    if (project.IsCloudHosted)
-                        tags += "<span class='yellow'>[cloud hosted]</span> ";
-                    
-                    if (project.IsRedacted)
-                    {
-                        OutputLines.Add($"• {tags}<span class='comment'>[REDACTED]</span>");
-                    }
-                    else if (!string.IsNullOrEmpty(project.Link))
-                    {
-                        OutputLines.Add($"• {tags}<a href='{project.Link}' target='_blank'>{project.Name}</a>");
-                    }
-                    else
-                    {
-                        OutputLines.Add($"• {tags}<span class='green'>{project.Name}</span>");
-                    }
-                }
+                DisplayProjects(Projects);
                 break;
             
             case "socials":
@@ -57,8 +37,6 @@ public partial class Terminal
 
             case "clear":
                 OutputLines.Clear();
-                OutputLines.Add(Header);
-                OutputLines.Add(""); 
                 break;
                 
             case "sudo":
@@ -74,6 +52,41 @@ public partial class Terminal
                 var encodedCmd = System.Net.WebUtility.HtmlEncode(cmd);
                 OutputLines.Add($"<span class='red'>Command not found: {encodedCmd}</span>");
                 break;
+        }
+    }
+
+    private void DisplayProjects(List<Project> projects, int indent = 0)
+    {
+        foreach (var project in projects)
+        {
+            var tags = new List<string>();
+            if (project.IsSelfHosted)
+                tags.Add("<span class='green'>[self hosted]</span>");
+            if (project.IsCli)
+                tags.Add("<span class='prompt-char'>[cli]</span>");
+            if (project.IsCloudHosted)
+                tags.Add("<span class='yellow'>[cloud hosted]</span>");
+            
+            var tagString = tags.Count > 0 ? string.Join(" ", tags) + " " : "";
+            var indentation = new string(' ', indent * 2);
+            
+            if (project.IsRedacted)
+            {
+                OutputLines.Add($"{indentation}• {tagString}<span class='comment'>[REDACTED]</span>");
+            }
+            else if (!string.IsNullOrEmpty(project.Link))
+            {
+                OutputLines.Add($"{indentation}• {tagString}<a href='{project.Link}' target='_blank'>{project.Name}</a>");
+            }
+            else
+            {
+                OutputLines.Add($"{indentation}• {tagString}<span class='green'>{project.Name}</span>");
+            }
+
+            if (project.Children.Count > 0)
+            {
+                DisplayProjects(project.Children, indent + 1);
+            }
         }
     }
 }

--- a/src/Components/Terminal.razor.Data.cs
+++ b/src/Components/Terminal.razor.Data.cs
@@ -4,33 +4,39 @@ namespace MitchfenSite.Components;
 
 public partial class Terminal
 {
-    private const string Header = "<span class='comment'>welcome to the mitchfen.com's TTY interface</span>";
-
     private List<Project> Projects = new()
     {
         new Project { 
-            Name = "Nanoleaf Aurora Controller", 
-            Description = "", 
-            Link = "https://github.com/mitchfen/nanoleaf-controller",
-            IsSelfHosted = true
-        },
-        new Project { 
-            Name = "WiZ Controller", 
-            Description = "", 
-            Link = "https://github.com/mitchfen/wiz-controller",
-            IsSelfHosted = true
-        },
-        new Project { 
-            Name = "Momentum", 
-            Description = "", 
-            Link = "https://github.com/mitchfen/momentum",
-            IsSelfHosted = true
-        },
-        new Project { 
-            Name = "Weight Tracker", 
-            Description = "", 
-            Link = "https://github.com/mitchfen/weight-tracker",
-            IsSelfHosted = true
+            Name = "My homelab ⚗️", 
+            Description = "Infrastructure and automation for my home lab.", 
+            Link = "https://github.com/mitchfen/homelab",
+            Children = new()
+            {
+                new Project { 
+                    Name = "Nanoleaf Aurora Controller", 
+                    Description = "", 
+                    Link = "https://github.com/mitchfen/nanoleaf-controller",
+                    IsSelfHosted = true
+                },
+                new Project { 
+                    Name = "WiZ Controller", 
+                    Description = "", 
+                    Link = "https://github.com/mitchfen/wiz-controller",
+                    IsSelfHosted = true
+                },
+                new Project { 
+                    Name = "Momentum", 
+                    Description = "", 
+                    Link = "https://github.com/mitchfen/momentum",
+                    IsSelfHosted = true
+                },
+                new Project { 
+                    Name = "Weight Tracker", 
+                    Description = "", 
+                    Link = "https://github.com/mitchfen/weight-tracker",
+                    IsSelfHosted = true
+                }
+            }
         },
         new Project { 
             Name = "mitchfen.com", 

--- a/src/Components/Terminal.razor.cs
+++ b/src/Components/Terminal.razor.cs
@@ -15,8 +15,6 @@ public partial class Terminal
 
     protected override void OnInitialized()
     {
-        OutputLines.Add(Header);
-        OutputLines.Add(""); 
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Models/Project.cs
+++ b/src/Models/Project.cs
@@ -9,4 +9,5 @@ public class Project
     public bool IsSelfHosted { get; set; }
     public bool IsCli { get; set; }
     public bool IsCloudHosted { get; set; }
+    public List<Project> Children { get; set; } = new();
 }


### PR DESCRIPTION
## Changes
- Add Children property to Project model for hierarchical structure
- Move Nanoleaf, WiZ Controller, Momentum, and Weight Tracker under homelab
- Rename 'Homelab' to 'My homelab ⚗️'
- Update help text from 'coding projects' to 'hobby projects'
- Implement recursive DisplayProjects method with proper indentation
- Fix tag spacing consistency in project display
- Remove welcome header from terminal initialization