### PR TITLE
Update homelab link to README.md with 'here' text

### DIFF
--- a/src/Components/Terminal.razor.Commands.cs
+++ b/src/Components/Terminal.razor.Commands.cs
@@ -16,7 +16,7 @@ public partial class Terminal
                 OutputLines.Add("<span class='green'>Welcome to Mitchell Fenner's personal website 🫡</span>");
                 OutputLines.Add("I'm a Senior Cloud Operations engineer and homelab enthusiast.");
                 OutputLines.Add("My work centers around Azure, Kubernetes, release management, Microsoft Sentinel, and automation of all kinds.");
-                OutputLines.Add("When I'm not working I'm often playing with my own bare metal server and home network. Check it out at <a href='https://github.com/mitchfen/homelab' target='_blank' rel='noopener noreferrer'>github.com/mitchfen/homelab</a>");
+                OutputLines.Add("When I'm not working I'm often playing with my own bare metal server and home network. Check it out <a href='https://github.com/mitchfen/homelab/blob/main/README.md' target='_blank' rel='noopener noreferrer'>here</a>.");
                 break;
             
             case "links":


### PR DESCRIPTION
Updates the homelab link in the welcome command to point to the README.md with 'here' as the clickable text.