### PR TITLE
Pin all GitHub Actions to specific commit SHAs

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -26,15 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           dotnet-version: '10.0.x'
 
       - name: Cache Nuget packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ~/.nuget/packages
           key: nuget-packages-${{ hashFiles('Directory.Packages.props') }}
@@ -44,7 +44,7 @@ jobs:
         run: dotnet run --project ./build/NukeBuild.csproj --target Publish
 
       - name: Upload output directory
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: output
           path: ./output
@@ -60,21 +60,21 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
           dotnet-version: '10.0.x'
 
       - name: Download output from build job
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: output
           path: output
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v4
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -96,14 +96,14 @@ jobs:
       url: ${{ steps.deploy.outputs.static_web_app_url }}
     steps:
       - name: Download output from build job
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: output
           path: output
 
       - name: Build And Deploy
         id: deploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_DEPLOYMENT_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations

--- a/.github/workflows/closeStaging.yml
+++ b/.github/workflows/closeStaging.yml
@@ -12,7 +12,7 @@ jobs:
     name: Close staging environment ${{ github.event.number }}
     steps:
       - name: Close staging environment
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_DEPLOYMENT_TOKEN }}
           action: "close"

--- a/readme.md
+++ b/readme.md
@@ -1,2 +1,2 @@
-Mitchell Fenner's personal site built with Blazor WebAssembly.
+Mitchell Fenner's personal site built with Blazor WebAssembly: https://mitchfen.com
 


### PR DESCRIPTION
Security improvement: Pin all GitHub Actions to their specific commit SHAs for reproducibility and security.

Changes:
- Pin actions/checkout, setup-dotnet, cache, upload-artifact, and download-artifact
- Pin docker/login-action and Azure/static-web-apps-deploy
- Add website URL to readme